### PR TITLE
Expose pinned nixpkgs source and version attrs

### DIFF
--- a/pinnedNixpkgs.nix
+++ b/pinnedNixpkgs.nix
@@ -1,13 +1,15 @@
 { channel ? "nixpkgs-unstable", versionFile }:
 
-let
+rec {
   version = builtins.fromJSON (builtins.readFile versionFile);
-in rec {
-  pkgs = import (builtins.fetchGit {
+
+  src = builtins.fetchGit {
     inherit (version) url rev;
 
     ref = channel;
-  }) {};
+  };
+
+  pkgs = import src {};
 
   updateScript = ''
     ${pkgs.nix-prefetch-git}/bin/nix-prefetch-git \


### PR DESCRIPTION
This information might be useful for re-using the source or version data.